### PR TITLE
Add combat timer and combat penalties

### DIFF
--- a/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
+++ b/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
@@ -1,0 +1,54 @@
+package com.extrahelden.duelmod.combat;
+
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages combat timers for players.
+ */
+public final class CombatManager {
+    private static final Map<UUID, CombatTimer> TIMERS = new ConcurrentHashMap<>();
+    public static final int EXTEND_TICKS = 20 * 30; // 30 seconds
+
+    private CombatManager() {
+    }
+
+    /**
+     * Put the player into combat or extend their timer.
+     */
+    public static void enterCombat(ServerPlayer player) {
+        TIMERS.compute(player.getUUID(), (uuid, timer) -> {
+            if (timer == null) {
+                return new CombatTimer(EXTEND_TICKS);
+            }
+            timer.addTicks(EXTEND_TICKS);
+            return timer;
+        });
+    }
+
+    /**
+     * Check if the player currently has an active combat timer.
+     */
+    public static boolean isInCombat(ServerPlayer player) {
+        CombatTimer timer = TIMERS.get(player.getUUID());
+        return timer != null && timer.isActive();
+    }
+
+    /**
+     * Tick all combat timers and remove expired ones.
+     */
+    public static void tick() {
+        TIMERS.entrySet().removeIf(entry -> !entry.getValue().tick());
+    }
+
+    /**
+     * Remove a player's combat timer.
+     */
+    public static void remove(ServerPlayer player) {
+        TIMERS.remove(player.getUUID());
+    }
+}
+

--- a/src/main/java/com/extrahelden/duelmod/combat/CombatTimer.java
+++ b/src/main/java/com/extrahelden/duelmod/combat/CombatTimer.java
@@ -1,0 +1,38 @@
+package com.extrahelden.duelmod.combat;
+
+/**
+ * Simple tick-based combat timer.
+ */
+public class CombatTimer {
+    private int ticks;
+
+    public CombatTimer(int ticks) {
+        this.ticks = ticks;
+    }
+
+    /**
+     * Add ticks to this timer.
+     *
+     * @param extraTicks ticks to add
+     */
+    public void addTicks(int extraTicks) {
+        this.ticks += extraTicks;
+    }
+
+    /**
+     * Decrement the timer by one tick.
+     *
+     * @return {@code true} if timer is still active after ticking
+     */
+    public boolean tick() {
+        if (ticks > 0) {
+            ticks--;
+        }
+        return ticks > 0;
+    }
+
+    public boolean isActive() {
+        return ticks > 0;
+    }
+}
+

--- a/src/main/java/com/extrahelden/duelmod/handler/MyForgeEventHandler.java
+++ b/src/main/java/com/extrahelden/duelmod/handler/MyForgeEventHandler.java
@@ -4,6 +4,7 @@ import com.extrahelden.duelmod.DuelMod;
 import com.extrahelden.duelmod.effect.ModEffects;
 import com.extrahelden.duelmod.helper.Helper;
 import com.extrahelden.duelmod.util.LinkedHeartOwnerHelper;
+import com.extrahelden.duelmod.combat.CombatManager;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -15,6 +16,8 @@ import net.minecraft.server.players.UserBanListEntry;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -22,9 +25,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Mod.EventBusSubscriber(modid = DuelMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class MyForgeEventHandler {
@@ -91,6 +92,9 @@ public class MyForgeEventHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLivingDeath(LivingDeathEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer victim)) return;
+
+        if (!CombatManager.isInCombat(victim)) return;
+        CombatManager.remove(victim);
 
         CompoundTag data = victim.getPersistentData();
 
@@ -223,6 +227,9 @@ public class MyForgeEventHandler {
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
 
 
+        if (!CombatManager.isInCombat(player)) return;
+        CombatManager.remove(player);
+
         CompoundTag data = player.getPersistentData();
         int newLives = Math.max(0, data.getInt("MyLives") - 1);
         data.putInt("MyLives", newLives);
@@ -312,6 +319,26 @@ public class MyForgeEventHandler {
                 ));
             }
         });
+    }
+
+    // =========================
+    // COMBAT HANDLING
+    // =========================
+    @SubscribeEvent
+    public static void onLivingHurt(LivingHurtEvent event) {
+        if (event.getEntity() instanceof ServerPlayer victim) {
+            if (event.getSource().getEntity() instanceof ServerPlayer attacker) {
+                CombatManager.enterCombat(victim);
+                CombatManager.enterCombat(attacker);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            CombatManager.tick();
+        }
     }
 
     // =========================


### PR DESCRIPTION
## Summary
- track combat status for players with a 30s timer
- lose a life if dying or logging out while in combat

## Testing
- `./gradlew test` *(fails: Resolve dependencies of :compileClasspath)*

------
https://chatgpt.com/codex/tasks/task_e_68b36ee397208320af83e68928a15c3e