### PR TITLE
Log combat status at info level

### DIFF
--- a/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
+++ b/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
@@ -30,7 +30,7 @@ public final class CombatManager {
             return existing;
         });
 
-        DuelMod.LOGGER.debug("Player {} is in combat ({} ticks remaining)",
+        DuelMod.LOGGER.info("Player {} is in combat ({} ticks remaining)",
                 player.getGameProfile().getName(), timer.getTicks());
 
     }


### PR DESCRIPTION
## Summary
- Switch combat entry log from debug to info so messages appear on the server console

## Testing
- `./gradlew build -x test`
- `java -cp /tmp/combat_test/bin com.extrahelden.duelmod.combat.TestCombatMain`


------
https://chatgpt.com/codex/tasks/task_e_68b38c3548588320961d71d46d115975