### PR TITLE
Show combat timer in action bar

### DIFF
--- a/src/main/java/com/extrahelden/duelmod/DuelMod.java
+++ b/src/main/java/com/extrahelden/duelmod/DuelMod.java
@@ -1,6 +1,10 @@
 package com.extrahelden.duelmod;
 
 import com.extrahelden.duelmod.command.ShowLivesCommand;
+import com.extrahelden.duelmod.command.LiveCommand;
+import com.extrahelden.duelmod.command.DuelCommand;
+import com.extrahelden.duelmod.command.AcceptCommand;
+import com.extrahelden.duelmod.command.DenyCommand;
 import com.extrahelden.duelmod.effect.ModEffects;
 import com.extrahelden.duelmod.handler.DeathHandler;
 import com.extrahelden.duelmod.handler.ModEntities;
@@ -76,6 +80,10 @@ public class DuelMod {
 
     private void onRegisterCommands(RegisterCommandsEvent event) {
         ShowLivesCommand.register(event.getDispatcher());
+        LiveCommand.register(event.getDispatcher());
+        DuelCommand.register(event.getDispatcher());
+        AcceptCommand.register(event.getDispatcher());
+        DenyCommand.register(event.getDispatcher());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/extrahelden/duelmod/client/ClientForgeEvents.java
+++ b/src/main/java/com/extrahelden/duelmod/client/ClientForgeEvents.java
@@ -10,12 +10,18 @@ import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(modid = DuelMod.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientForgeEvents {
+    private static boolean combatDeath;
+
+    public static void markCombatDeath() {
+        combatDeath = true;
+    }
 
     @SubscribeEvent
     public static void onScreenOpen(ScreenEvent.Opening event) {
-        if (event.getScreen() instanceof DeathScreen old && !(event.getScreen() instanceof CustomDeathScreen)) {
+        if (combatDeath && event.getScreen() instanceof DeathScreen old && !(event.getScreen() instanceof CustomDeathScreen)) {
             System.out.println("[DuelMod] Replacing DeathScreen with CustomDeathScreen");
             event.setNewScreen(new CustomDeathScreen(old.getTitle(), true));
+            combatDeath = false;
         }
     }
 }

--- a/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
+++ b/src/main/java/com/extrahelden/duelmod/combat/CombatManager.java
@@ -1,0 +1,102 @@
+package com.extrahelden.duelmod.combat;
+
+import com.extrahelden.duelmod.DuelMod;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages combat timers for players.
+ */
+public final class CombatManager {
+    private static final Map<UUID, CombatTimer> TIMERS = new ConcurrentHashMap<>();
+    private static final Map<UUID, UUID> PARTNERS = new ConcurrentHashMap<>();
+    public static final int EXTEND_TICKS = 20 * 30; // 30 seconds
+
+    private CombatManager() {
+    }
+
+    private static CombatTimer extendTimer(ServerPlayer player) {
+        return TIMERS.compute(player.getUUID(), (uuid, existing) -> {
+            if (existing == null) {
+                return new CombatTimer(EXTEND_TICKS);
+            }
+            existing.addTicks(EXTEND_TICKS);
+            return existing;
+        });
+    }
+
+    /**
+     * Put both players into combat or extend their timers and link them as combat partners.
+     */
+    public static void engage(ServerPlayer a, ServerPlayer b) {
+        CombatTimer ta = extendTimer(a);
+        CombatTimer tb = extendTimer(b);
+        PARTNERS.put(a.getUUID(), b.getUUID());
+        PARTNERS.put(b.getUUID(), a.getUUID());
+        DuelMod.LOGGER.debug("Player {} is in combat with {} ({} ticks remaining)",
+                a.getGameProfile().getName(), b.getGameProfile().getName(), ta.getTicks());
+        DuelMod.LOGGER.debug("Player {} is in combat with {} ({} ticks remaining)",
+                b.getGameProfile().getName(), a.getGameProfile().getName(), tb.getTicks());
+    }
+
+    /**
+     * Check if the player currently has an active combat timer.
+     */
+    public static boolean isInCombat(ServerPlayer player) {
+        CombatTimer timer = TIMERS.get(player.getUUID());
+        return timer != null && timer.isActive();
+    }
+
+    /**
+     * Get remaining ticks of combat for the given player.
+     *
+     * @param player player to check
+     * @return remaining ticks or {@code 0} if not in combat
+     */
+    public static int getRemainingTicks(ServerPlayer player) {
+        CombatTimer timer = TIMERS.get(player.getUUID());
+        return timer != null ? timer.getTicks() : 0;
+    }
+
+    /**
+     * Tick all combat timers and remove expired ones.
+     */
+    public static void tick() {
+        Iterator<Map.Entry<UUID, CombatTimer>> it = TIMERS.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<UUID, CombatTimer> entry = it.next();
+            if (!entry.getValue().tick()) {
+                UUID id = entry.getKey();
+                it.remove();
+                UUID partner = PARTNERS.remove(id);
+                if (partner != null) {
+                    UUID back = PARTNERS.get(partner);
+                    if (back != null && back.equals(id)) {
+                        PARTNERS.remove(partner);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove a player's combat timer.
+     */
+    public static void remove(ServerPlayer player) {
+        UUID id = player.getUUID();
+        TIMERS.remove(id);
+        UUID partner = PARTNERS.remove(id);
+        if (partner != null) {
+            TIMERS.remove(partner);
+            UUID back = PARTNERS.get(partner);
+            if (back != null && back.equals(id)) {
+                PARTNERS.remove(partner);
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/extrahelden/duelmod/combat/CombatTimer.java
+++ b/src/main/java/com/extrahelden/duelmod/combat/CombatTimer.java
@@ -1,0 +1,45 @@
+package com.extrahelden.duelmod.combat;
+
+/**
+ * Simple tick-based combat timer.
+ */
+public class CombatTimer {
+    private int ticks;
+
+    public CombatTimer(int ticks) {
+        this.ticks = ticks;
+    }
+
+    /**
+     * Add ticks to this timer.
+     *
+     * @param extraTicks ticks to add
+     */
+    public void addTicks(int extraTicks) {
+        this.ticks += extraTicks;
+    }
+
+    /**
+     * Decrement the timer by one tick.
+     *
+     * @return {@code true} if timer is still active after ticking
+     */
+    public boolean tick() {
+        if (ticks > 0) {
+            ticks--;
+        }
+        return ticks > 0;
+    }
+
+    public boolean isActive() {
+        return ticks > 0;
+    }
+
+    /**
+     * Expose remaining ticks for debugging.
+     */
+    public int getTicks() {
+        return ticks;
+    }
+}
+

--- a/src/main/java/com/extrahelden/duelmod/command/AcceptCommand.java
+++ b/src/main/java/com/extrahelden/duelmod/command/AcceptCommand.java
@@ -1,0 +1,41 @@
+package com.extrahelden.duelmod.command;
+
+import com.extrahelden.duelmod.combat.CombatManager;
+import com.extrahelden.duelmod.duel.DuelManager;
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
+
+public class AcceptCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("accept")
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    UUID chalId = DuelManager.getPending(player);
+                    if (chalId == null) {
+                        player.sendSystemMessage(Component.literal("Du hast keine Duel-Anfragen."));
+                        return 1;
+                    }
+                    ServerPlayer challenger = player.getServer().getPlayerList().getPlayer(chalId);
+                    if (challenger == null) {
+                        DuelManager.deny(player);
+                        player.sendSystemMessage(Component.literal("Herausforderer nicht mehr online."));
+                        return 1;
+                    }
+                    if (DuelManager.accept(player)) {
+                        CombatManager.remove(challenger);
+                        CombatManager.remove(player);
+                        player.sendSystemMessage(Component.literal("Duel mit "
+                                + challenger.getGameProfile().getName() + " gestartet."));
+                        challenger.sendSystemMessage(Component.literal(player.getGameProfile().getName()
+                                + " hat das Duel angenommen."));
+                    }
+                    return 1;
+                }));
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/command/DenyCommand.java
+++ b/src/main/java/com/extrahelden/duelmod/command/DenyCommand.java
@@ -1,0 +1,33 @@
+package com.extrahelden.duelmod.command;
+
+import com.extrahelden.duelmod.duel.DuelManager;
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
+
+public class DenyCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("deny")
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    UUID chalId = DuelManager.getPending(player);
+                    if (chalId == null) {
+                        player.sendSystemMessage(Component.literal("Keine Duel-Anfrage."));
+                        return 1;
+                    }
+                    DuelManager.deny(player);
+                    ServerPlayer challenger = player.getServer().getPlayerList().getPlayer(chalId);
+                    if (challenger != null) {
+                        challenger.sendSystemMessage(Component.literal(player.getGameProfile().getName()
+                                + " hat dein Duel abgelehnt."));
+                    }
+                    player.sendSystemMessage(Component.literal("Duel abgelehnt."));
+                    return 1;
+                }));
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/command/DuelCommand.java
+++ b/src/main/java/com/extrahelden/duelmod/command/DuelCommand.java
@@ -1,0 +1,60 @@
+package com.extrahelden.duelmod.command;
+
+import com.extrahelden.duelmod.duel.DuelManager;
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.Vec3;
+
+public class DuelCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("duel")
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    if (!DuelManager.canChallenge(player)) {
+                        player.sendSystemMessage(Component.literal("Du kannst keine weiteren Duelle starten."));
+                        return 1;
+                    }
+                    ServerPlayer target = findTarget(player);
+                    if (target == null) {
+                        player.sendSystemMessage(Component.literal("Kein Spieler vor dir."));
+                        return 1;
+                    }
+                    if (DuelManager.isInDuel(player) || DuelManager.isInDuel(target)) {
+                        player.sendSystemMessage(Component.literal("Einer der Spieler ist bereits in einem Duel."));
+                        return 1;
+                    }
+                    DuelManager.request(player, target);
+                    DuelManager.recordUse(player);
+                    player.sendSystemMessage(Component.literal("Du hast "
+                            + target.getGameProfile().getName() + " zu einem Duel herausgefordert."));
+                    target.sendSystemMessage(Component.literal(player.getGameProfile().getName()
+                            + " hat dich zu einem Duel herausgefordert. Tippe /accept zum Annehmen oder /deny zum Ablehnen."));
+                    return 1;
+                }));
+    }
+
+    private static ServerPlayer findTarget(ServerPlayer source) {
+        double maxDist = 5.0;
+        Vec3 eye = source.getEyePosition();
+        Vec3 look = source.getLookAngle();
+        ServerPlayer result = null;
+        double best = maxDist;
+        for (ServerPlayer other : source.server.getPlayerList().getPlayers()) {
+            if (other == source) continue;
+            Vec3 to = other.getEyePosition().subtract(eye);
+            double dist = to.length();
+            if (dist <= maxDist) {
+                to = to.normalize();
+                if (to.dot(look) > 0.8 && dist < best) {
+                    result = other;
+                    best = dist;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/command/LiveCommand.java
+++ b/src/main/java/com/extrahelden/duelmod/command/LiveCommand.java
@@ -1,0 +1,42 @@
+package com.extrahelden.duelmod.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.scores.PlayerTeam;
+import net.minecraft.world.scores.Scoreboard;
+
+public class LiveCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("live")
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    CompoundTag data = player.getPersistentData();
+                    Scoreboard board = player.getScoreboard();
+                    String teamName = "live_" + player.getScoreboardName();
+                    PlayerTeam team = board.getPlayerTeam(teamName);
+                    if (data.getBoolean("LivePrefix")) {
+                        if (team != null) {
+                            board.removePlayerFromTeam(player.getScoreboardName(), team);
+                            board.removePlayerTeam(team);
+                        }
+                        data.putBoolean("LivePrefix", false);
+                        player.sendSystemMessage(Component.literal("Live-Modus deaktiviert"));
+                    } else {
+                        if (team == null) {
+                            team = board.addPlayerTeam(teamName);
+                        }
+                        team.setPlayerPrefix(Component.literal("Live ").withStyle(ChatFormatting.RED));
+                        board.addPlayerToTeam(player.getScoreboardName(), team);
+                        data.putBoolean("LivePrefix", true);
+                        player.sendSystemMessage(Component.literal("Live-Modus aktiviert"));
+                    }
+                    return 1;
+                }));
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/duel/DuelManager.java
+++ b/src/main/java/com/extrahelden/duelmod/duel/DuelManager.java
@@ -1,0 +1,71 @@
+package com.extrahelden.duelmod.duel;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks duel requests and active duels between players.
+ */
+public final class DuelManager {
+    private static final Map<UUID, UUID> PENDING = new ConcurrentHashMap<>(); // target -> challenger
+    private static final Map<UUID, UUID> ACTIVE = new ConcurrentHashMap<>(); // player -> opponent
+    private static final Map<UUID, Integer> USES = new ConcurrentHashMap<>(); // player -> /duel uses
+
+    private DuelManager() {
+    }
+
+    public static boolean canChallenge(ServerPlayer player) {
+        return USES.getOrDefault(player.getUUID(), 0) < 3;
+    }
+
+    public static void recordUse(ServerPlayer player) {
+        USES.merge(player.getUUID(), 1, Integer::sum);
+    }
+
+    public static void request(ServerPlayer challenger, ServerPlayer target) {
+        PENDING.put(target.getUUID(), challenger.getUUID());
+    }
+
+    public static UUID getPending(ServerPlayer target) {
+        return PENDING.get(target.getUUID());
+    }
+
+    public static void deny(ServerPlayer target) {
+        PENDING.remove(target.getUUID());
+    }
+
+    public static boolean accept(ServerPlayer target) {
+        UUID chalId = PENDING.remove(target.getUUID());
+        if (chalId == null) return false;
+        ServerPlayer challenger = target.getServer().getPlayerList().getPlayer(chalId);
+        if (challenger == null) return false;
+        ACTIVE.put(chalId, target.getUUID());
+        ACTIVE.put(target.getUUID(), chalId);
+        return true;
+    }
+
+    public static boolean isInDuel(ServerPlayer player) {
+        return ACTIVE.containsKey(player.getUUID());
+    }
+
+    public static ServerPlayer getOpponent(ServerPlayer player) {
+        UUID opp = ACTIVE.get(player.getUUID());
+        if (opp == null) return null;
+        return player.getServer().getPlayerList().getPlayer(opp);
+    }
+
+    public static void end(ServerPlayer player) {
+        UUID oppId = ACTIVE.remove(player.getUUID());
+        if (oppId != null) {
+            ACTIVE.remove(oppId);
+            ServerPlayer opp = player.getServer().getPlayerList().getPlayer(oppId);
+            if (opp != null) {
+                opp.sendSystemMessage(Component.literal(player.getGameProfile().getName() + " hat das Duel beendet."));
+            }
+        }
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/events/CommonEvents.java
+++ b/src/main/java/com/extrahelden/duelmod/events/CommonEvents.java
@@ -2,6 +2,7 @@ package com.extrahelden.duelmod.events;
 
 import com.extrahelden.duelmod.DuelMod;
 import com.extrahelden.duelmod.handler.DummyManager;
+import com.extrahelden.duelmod.combat.CombatTimer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;

--- a/src/main/java/com/extrahelden/duelmod/handler/MyForgeEventHandler.java
+++ b/src/main/java/com/extrahelden/duelmod/handler/MyForgeEventHandler.java
@@ -4,6 +4,8 @@ import com.extrahelden.duelmod.DuelMod;
 import com.extrahelden.duelmod.effect.ModEffects;
 import com.extrahelden.duelmod.helper.Helper;
 import com.extrahelden.duelmod.util.LinkedHeartOwnerHelper;
+import com.extrahelden.duelmod.combat.CombatManager;
+import com.extrahelden.duelmod.duel.DuelManager;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -15,6 +17,8 @@ import net.minecraft.server.players.UserBanListEntry;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -22,9 +26,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Mod.EventBusSubscriber(modid = DuelMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class MyForgeEventHandler {
@@ -83,6 +85,17 @@ public class MyForgeEventHandler {
                     Helper.getPrefix() + "§a Dein Linked Heart ist aktiv."
             ));
         }
+
+        if (data.getBoolean("LivePrefix")) {
+            var board = player.getScoreboard();
+            String teamName = "live_" + player.getScoreboardName();
+            var team = board.getPlayerTeam(teamName);
+            if (team == null) {
+                team = board.addPlayerTeam(teamName);
+            }
+            team.setPlayerPrefix(Component.literal("Live ").withStyle(ChatFormatting.RED));
+            board.addPlayerToTeam(player.getScoreboardName(), team);
+        }
     }
 
     // =========================
@@ -91,6 +104,23 @@ public class MyForgeEventHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLivingDeath(LivingDeathEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer victim)) return;
+
+        if (DuelManager.isInDuel(victim)) {
+            ServerPlayer opponent = DuelManager.getOpponent(victim);
+            DuelManager.end(victim);
+            if (opponent != null) {
+                opponent.sendSystemMessage(Component.literal(victim.getGameProfile().getName() + " ist im Duel gestorben."));
+                opponent.displayClientMessage(
+                        Component.literal("Du hast das Duel gewonnen").withStyle(ChatFormatting.AQUA),
+                        true
+                );
+            }
+            return;
+        }
+
+        if (!CombatManager.isInCombat(victim)) return;
+        CombatManager.remove(victim);
+        com.extrahelden.duelmod.network.NetworkHandler.sendCombatDeath(victim);
 
         CompoundTag data = victim.getPersistentData();
 
@@ -222,6 +252,13 @@ public class MyForgeEventHandler {
     public static void onPlayerLogout(PlayerLoggedOutEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
 
+        if (DuelManager.isInDuel(player)) {
+            DuelManager.end(player);
+            return;
+        }
+
+        if (!CombatManager.isInCombat(player)) return;
+        CombatManager.remove(player);
 
         CompoundTag data = player.getPersistentData();
         int newLives = Math.max(0, data.getInt("MyLives") - 1);
@@ -312,6 +349,41 @@ public class MyForgeEventHandler {
                 ));
             }
         });
+    }
+
+    // =========================
+    // COMBAT HANDLING
+    // =========================
+    @SubscribeEvent
+    public static void onLivingHurt(LivingHurtEvent event) {
+        if (event.getEntity() instanceof ServerPlayer victim) {
+            if (event.getSource().getEntity() instanceof ServerPlayer attacker) {
+                if (!DuelManager.isInDuel(attacker) && !DuelManager.isInDuel(victim)) {
+                    CombatManager.engage(attacker, victim);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            CombatManager.tick();
+            var server = event.getServer();
+            if (server != null) {
+                for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+                    int ticks = CombatManager.getRemainingTicks(player);
+                    if (ticks > 0) {
+                        int seconds = (ticks + 19) / 20;
+                        player.displayClientMessage(
+                                Component.literal("Im Kampf! ").withStyle(ChatFormatting.RED)
+                                        .append(Component.literal("(" + seconds + " s übrig)")
+                                                .withStyle(ChatFormatting.GRAY)),
+                                true);
+                    }
+                }
+            }
+        }
     }
 
     // =========================

--- a/src/main/java/com/extrahelden/duelmod/network/CombatDeathS2CPacket.java
+++ b/src/main/java/com/extrahelden/duelmod/network/CombatDeathS2CPacket.java
@@ -1,0 +1,25 @@
+package com.extrahelden.duelmod.network;
+
+import com.extrahelden.duelmod.client.ClientForgeEvents;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+/** Notification that the player died while in combat. */
+public record CombatDeathS2CPacket() {
+
+    public static void encode(CombatDeathS2CPacket pkt, FriendlyByteBuf buf) {
+        // no payload
+    }
+
+    public static CombatDeathS2CPacket decode(FriendlyByteBuf buf) {
+        return new CombatDeathS2CPacket();
+    }
+
+    public static void handle(CombatDeathS2CPacket pkt, Supplier<NetworkEvent.Context> ctxSup) {
+        NetworkEvent.Context ctx = ctxSup.get();
+        ctx.enqueueWork(ClientForgeEvents::markCombatDeath);
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/extrahelden/duelmod/network/NetworkHandler.java
+++ b/src/main/java/com/extrahelden/duelmod/network/NetworkHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.network.simple.SimpleChannel;
+import com.extrahelden.duelmod.network.CombatDeathS2CPacket;
 
 public final class NetworkHandler {
     private static final String PROTOCOL = "1";
@@ -30,6 +31,14 @@ public final class NetworkHandler {
                SyncLivesS2CPacket::decode,
                SyncLivesS2CPacket::handle
        );
+
+       CHANNEL.registerMessage(
+               id++,
+               CombatDeathS2CPacket.class,
+               CombatDeathS2CPacket::encode,
+               CombatDeathS2CPacket::decode,
+               CombatDeathS2CPacket::handle
+       );
     }
 
 
@@ -42,5 +51,12 @@ public final class NetworkHandler {
                  new SyncLivesS2CPacket(lives, ownerName, ownerUuid, linkedActive)
          );
     };
+
+    public static void sendCombatDeath(ServerPlayer player) {
+        CHANNEL.send(
+                PacketDistributor.PLAYER.with(() -> player),
+                new CombatDeathS2CPacket()
+        );
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose remaining combat ticks via `CombatManager.getRemainingTicks`
- push remaining combat time to players' action bars each server tick, formatted as `Im Kampf! (Xs übrig)`
- tint the remaining-time parentheses gray for clearer contrast
- link combat partners so if one dies or logs out, both players leave combat
- add `/live` command to toggle a red "Live" prefix in the tab list and reapply it on login
- show custom death screen only when a player dies while in combat
- implement a duel system with `/duel`, `/accept`, and `/deny` commands that bypass combat penalties and limit challenges to three per player
- notify the surviving player with a turquoise action-bar message when their opponent dies in a duel

## Testing
- `bash ./gradlew test` *(hangs after "Daemon will be stopped at the end of the build")*


------
https://chatgpt.com/codex/tasks/task_e_68b36ee397208320af83e68928a15c3e