### PR TITLE
Add placeholder `clan_chest` block/item registry to prevent startup NPE

### DIFF
--- a/src/main/java/com/extrahelden/duelmod/DuelMod.java
+++ b/src/main/java/com/extrahelden/duelmod/DuelMod.java
@@ -2,6 +2,7 @@ package com.extrahelden.duelmod;
 
 import com.extrahelden.duelmod.effect.ModEffects;
 import com.extrahelden.duelmod.handler.DeathHandler;
+import com.extrahelden.duelmod.handler.ModBlocks;
 import com.extrahelden.duelmod.handler.ModEntities;
 import com.extrahelden.duelmod.handler.MyForgeEventHandler;
 import com.extrahelden.duelmod.network.NetworkHandler;
@@ -50,6 +51,7 @@ public class DuelMod {
         // ----- Registries -----
         ModEffects.register(modBus);
         ModEntities.register(modBus);
+        ModBlocks.register(modBus);
 
         // ----- Forge EventBus -----
         MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);

--- a/src/main/java/com/extrahelden/duelmod/handler/ModBlocks.java
+++ b/src/main/java/com/extrahelden/duelmod/handler/ModBlocks.java
@@ -1,0 +1,37 @@
+package com.extrahelden.duelmod.handler;
+
+import com.extrahelden.duelmod.DuelMod;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public final class ModBlocks {
+    private ModBlocks() {
+    }
+
+    public static final DeferredRegister<Block> BLOCKS =
+            DeferredRegister.create(ForgeRegistries.BLOCKS, DuelMod.MOD_ID);
+    public static final DeferredRegister<Item> ITEMS =
+            DeferredRegister.create(ForgeRegistries.ITEMS, DuelMod.MOD_ID);
+
+    public static final RegistryObject<Block> CLAN_CHEST = BLOCKS.register(
+            "clan_chest",
+            () -> new Block(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS))
+    );
+
+    public static final RegistryObject<Item> CLAN_CHEST_ITEM = ITEMS.register(
+            "clan_chest",
+            () -> new BlockItem(CLAN_CHEST.get(), new Item.Properties())
+    );
+
+    public static void register(IEventBus bus) {
+        BLOCKS.register(bus);
+        ITEMS.register(bus);
+    }
+}


### PR DESCRIPTION
### Motivation
- Startup was crashing with a suppressed `NullPointerException: Registry Object not present: duelmod:clan_chest` during deferred client work, indicating the `clan_chest` registry entry was missing. 
- Provide a minimal placeholder registry so code that expects `duelmod:clan_chest` can safely access the `RegistryObject` during initialization and avoid the runtime crash.

### Description
- Add a new registry handler `ModBlocks` that defines a placeholder `clan_chest` `Block` and corresponding `BlockItem` using `DeferredRegister` (`src/main/java/com/extrahelden/duelmod/handler/ModBlocks.java`).
- Register both `BLOCKS` and `ITEMS` in `ModBlocks.register(IEventBus)` so they are hooked into the mod event bus.
- Register the new `ModBlocks` during mod initialization by calling `ModBlocks.register(modBus)` in `DuelMod` and adding the necessary import (`src/main/java/com/extrahelden/duelmod/DuelMod.java`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce09fc9188320bd81a5952a0ed290)